### PR TITLE
Logfile config option bugfix

### DIFF
--- a/glacier/glacier.py
+++ b/glacier/glacier.py
@@ -614,7 +614,7 @@ def main():
                         help="Amazon SimpleDB domain name for bookkeeping.")
     group.add_argument('--logfile',
                        required=False,
-                       default=os.path.expanduser('~/.glacier-cmd.log'),
+                       default=default('logfile') if default('logfile') else os.path.expanduser('~/.glacier-cmd.log'),
                        help='File to write log messages to.')
     group.add_argument('--loglevel',
                        required=False,


### PR DESCRIPTION
Brings fix fox logfile option in config being ignored.

> Setting the `logfile=` option in the `[glacier]` section of a config had no effect. The logfile variable was simply being silently discarded. After this patch, the option works as expected.